### PR TITLE
Fix duplicate monitoring settings

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -163,22 +163,6 @@ class Settings(BaseSettings):
     JWT_ROTATION_ALERT_ON_ERROR: bool = True  # Send alerts on rotation errors
     JWT_ROTATION_ALERT_ON_RETRY: bool = False  # Send alerts on retries
 
-    # --- Monitoring & Alerting Settings ------------------------------------
-    # Prometheus metrics endpoint configuration
-    PROMETHEUS_ENABLED: bool = True  # Enable/disable Prometheus metrics
-    PROMETHEUS_PORT: int = 9090  # Port for Prometheus metrics server
-    PROMETHEUS_HOST: str = "0.0.0.0"  # Host for Prometheus metrics server
-
-    # Slack webhook alerting configuration
-    SLACK_WEBHOOK_URL: Optional[str] = None  # Slack webhook URL for alerts
-    SLACK_ALERTING_ENABLED: bool = False  # Enable/disable Slack alerting
-    SLACK_MAX_ALERTS_PER_HOUR: int = 10  # Rate limiting for alerts
-    SLACK_TIMEOUT_SECONDS: int = 10  # HTTP timeout for webhook requests
-
-    # JWT rotation alerting thresholds
-    JWT_ROTATION_ALERT_ON_ERROR: bool = True  # Send alerts on rotation errors
-    JWT_ROTATION_ALERT_ON_RETRY: bool = False  # Send alerts on retries
-
 
 settings = Settings()
 


### PR DESCRIPTION
## Summary
- remove extra monitoring settings section in config to avoid duplication

## Testing
- `make test-backend` *(fails: invalid database URL)*